### PR TITLE
Pin pyldapi version to v2.1.3

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,7 +3,7 @@ flask
 flask_paginate
 lxml
 rdflib
-pyldapi
+pyldapi==v2.1.3
 pytest
 shapely
 geojson


### PR DESCRIPTION
The current requirements.txt file doesn't specify a version and since then pyldapi have pushed version 3 (that is not backwards compatible). This PR specifies which pyldapi we're currently working off (v2.1.3). 