### PR TITLE
adding a wrapper to append featurecollection

### DIFF
--- a/api/view/templates/page_geometry.html
+++ b/api/view/templates/page_geometry.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "geom_page_layout.html" %}
 
 {% block content %}
     <h1>Geometry</h1>


### PR DESCRIPTION
This PR introduces a view that provides a featurecollection wrapper to the geometry object being served. This allows reading of the data via URL by clients like QGIS.